### PR TITLE
Added protected method to allow remote repo builder to be modified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,12 @@ You can also configure the repositories programmatically using the `setHttpProxy
 Basic authentication can be achieved by adding a username and/or password in the repository or proxy configuration.
 For instance `http://julien:secret@myrepository.com/` will configure to use `julien` username and `secret` password if the
 remote server needs authentication. Proxies are also supported.
+
+## Configuring Remote Snapshot Refresh Policy
+
+By default SNAPSHOT dependencies are update once a day. This behavior can be modified using the system property `vertx.maven.remoteSnapshotPolicy`.
+This can be set to `always` to ensure SNAPSHOT dependencies are updated every single time, `daily` to update just once a day, which is the default, or `never`
+to ensure they are never udpated.
+
+It can also be set to `interval:X` where `X` is the number of minutes to allow before updating a SNAPSHOT dependency.
+

--- a/core/src/main/java/io/vertx/maven/MavenVerticleFactory.java
+++ b/core/src/main/java/io/vertx/maven/MavenVerticleFactory.java
@@ -15,10 +15,7 @@ import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.eclipse.aether.repository.Authentication;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.Proxy;
-import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.*;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
@@ -51,6 +48,7 @@ public class MavenVerticleFactory extends ServiceVerticleFactory {
   public static final String REMOTE_REPOS_SYS_PROP = "vertx.maven.remoteRepos";
   public static final String HTTP_PROXY_SYS_PROP = "vertx.maven.httpProxy";
   public static final String HTTPS_PROXY_SYS_PROP = "vertx.maven.httpsProxy";
+  public static final String REMOTE_SNAPSHOT_POLICY_SYS_PROP = "vertx.maven.remoteSnapshotPolicy";
 
   private static final String USER_HOME = System.getProperty("user.home");
   private static final String FILE_SEP = System.getProperty("file.separator");
@@ -153,6 +151,7 @@ public class MavenVerticleFactory extends ServiceVerticleFactory {
               }
               break;
           }
+          customizeRemoteRepoBuilder(builder);
           RemoteRepository remoteRepo = builder.build();
           remotes.add(remoteRepo);
         }
@@ -226,6 +225,13 @@ public class MavenVerticleFactory extends ServiceVerticleFactory {
       }
     }, ar -> {
     });
+  }
+
+  protected void customizeRemoteRepoBuilder(RemoteRepository.Builder builder) {
+    String updatePolicy = System.getProperty(REMOTE_SNAPSHOT_POLICY_SYS_PROP);
+    if (updatePolicy != null && !updatePolicy.isEmpty()) {
+      builder.setSnapshotPolicy(new RepositoryPolicy(true, updatePolicy, RepositoryPolicy.CHECKSUM_POLICY_WARN));
+    }
   }
 
   public String getLocalMavenRepo() {

--- a/core/src/test/java/io/vertx/maven/MavenVerticleFactoryTest.java
+++ b/core/src/test/java/io/vertx/maven/MavenVerticleFactoryTest.java
@@ -1,0 +1,38 @@
+package io.vertx.maven;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * @author <a href="mailto:john.warner@ef.com">John Warner</a>
+ */
+public class MavenVerticleFactoryTest {
+    @Test
+    public void testWithoutSystemProperty() throws Exception {
+        // Ensure the property is empty
+        System.clearProperty(MavenVerticleFactory.REMOTE_SNAPSHOT_POLICY_SYS_PROP);
+
+        MavenVerticleFactory mavenVerticleFactory = new MavenVerticleFactory();
+        RemoteRepository.Builder builder = new RemoteRepository.Builder("test", "default", "http://test.com");
+
+        mavenVerticleFactory.customizeRemoteRepoBuilder(builder);
+
+        assertEquals(RepositoryPolicy.UPDATE_POLICY_DAILY, builder.build().getPolicy(true).getUpdatePolicy());
+    }
+
+    @Test
+    public void testWithSystemProperty() throws Exception {
+        // Set the property to update daily
+        System.setProperty(MavenVerticleFactory.REMOTE_SNAPSHOT_POLICY_SYS_PROP, RepositoryPolicy.UPDATE_POLICY_ALWAYS);
+
+        MavenVerticleFactory mavenVerticleFactory = new MavenVerticleFactory();
+        RemoteRepository.Builder builder = new RemoteRepository.Builder("test", "default", "http://test.com");
+
+        mavenVerticleFactory.customizeRemoteRepoBuilder(builder);
+
+        assertEquals(RepositoryPolicy.UPDATE_POLICY_ALWAYS, builder.build().getPolicy(true).getUpdatePolicy());
+    }
+}


### PR DESCRIPTION
Added a new system property, `vertx.maven.remoteSnapshotPolicy` that allows us to modify the update policies for remote repos.

Also added a protected method that is called at the end of the process of creating a remote repo builder, but before it's built. It's protected so we can add further functionality by wrapping the class if need be.