### PR TITLE
Use HTTPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The default value is: `{user.home}/.m2/repository`
 The list of remote repositories can be configured using the `vertx.maven.remoteRepos` system property - this should
 contain a space separated list of urls to the remote repositories.
 
-The default valus is `http://central.maven.org/maven2/ http://oss.sonatype.org/content/repositories/snapshots/`
+The default valus is `https://repo.maven.apache.org/maven2/ https://oss.sonatype.org/content/repositories/snapshots/`
 
 ### Programmatically
 

--- a/core/src/main/java/io/vertx/maven/MavenVerticleFactory.java
+++ b/core/src/main/java/io/vertx/maven/MavenVerticleFactory.java
@@ -56,7 +56,7 @@ public class MavenVerticleFactory extends ServiceVerticleFactory {
   private static final String FILE_SEP = System.getProperty("file.separator");
   private static final String DEFAULT_MAVEN_LOCAL = USER_HOME + FILE_SEP + ".m2" + FILE_SEP + "repository";
   private static final String DEFAULT_MAVEN_REMOTES =
-    "http://central.maven.org/maven2/ http://oss.sonatype.org/content/repositories/snapshots/";
+    "https://repo.maven.apache.org/maven2/ https://oss.sonatype.org/content/repositories/snapshots/";
 
   private String localMavenRepo;
   private List<String> remoteMavenRepos;


### PR DESCRIPTION
Currently the default repositories (http://central.maven.org/maven2/ and http://oss.sonatype.org/content/repositories/snapshots/) use HTTP protocol. This PR updates the repositories to use HTTPS.